### PR TITLE
Add log level configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ http://code.tutsplus.com/tutorials/scheduling-tasks-with-cron-jobs--net-8800).
 Running the script with the `test` parameter is also a good idea, so you can
 ensure that good results come back from most of the providers.
 
-Logs are written to stdout/stderr and the default log level is info. You can
-chnage the log level by setting the `LOG_LEVEL` environment variable. Ex:
+Logs are written to stdout/stderr and the default log level is INFO. You can
+change the log level by setting the `LOG_LEVEL` environment variable. Ex:
 
 ```bash
 LOG_LEVEL=DEBUG ./gandi_dyndns.py

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ http://code.tutsplus.com/tutorials/scheduling-tasks-with-cron-jobs--net-8800).
 Running the script with the `test` parameter is also a good idea, so you can
 ensure that good results come back from most of the providers.
 
+Logs are written to stdout/stderr and the default log level is info. You can
+chnage the log level by setting the `LOG_LEVEL` environment variable. Ex:
+
+```bash
+LOG_LEVEL=DEBUG ./gandi_dyndns.py
+```
+
 #### Notes
 
 The first time your A record is configured, it may take several hours

--- a/gandi_dyndns.py
+++ b/gandi_dyndns.py
@@ -10,7 +10,11 @@ import urllib2
 import xmlrpclib
 
 import logging as log
-log.basicConfig(format='%(asctime)-15s [%(levelname)s] %(message)s', level=os.getenv('LOG_LEVEL', 'INFO'))
+LOG_LEVEL = log.getLevelName(os.getenv('LOG_LEVEL'))
+if not isinstance(LOG_LEVEL, int):
+  LOG_LEVEL = 20
+
+log.basicConfig(format='%(asctime)-15s [%(levelname)s] %(message)s', level=LOG_LEVEL)
 
 # matches all IPv4 addresses, including invalid ones. we look for
 # multiple-provider agreement before returning an IP.

--- a/gandi_dyndns.py
+++ b/gandi_dyndns.py
@@ -2,6 +2,7 @@
 
 import collections
 import json
+import os
 import random
 import re
 import time
@@ -9,7 +10,7 @@ import urllib2
 import xmlrpclib
 
 import logging as log
-log.basicConfig(format='%(asctime)-15s [%(levelname)s] %(message)s', level=log.DEBUG)
+log.basicConfig(format='%(asctime)-15s [%(levelname)s] %(message)s', level=os.getenv('LOG_LEVEL', 'INFO'))
 
 # matches all IPv4 addresses, including invalid ones. we look for
 # multiple-provider agreement before returning an IP.


### PR DESCRIPTION
This PR changes the default log level to INFO and allows users to set the level via the LOG_LEVEL environment variable, ex:

    $ LOG_LEVEL=DEBUG ./gandi_dyndns.py