### PR TITLE
Use optional shell command to determine external IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ Then you'd need to configure the script.
     }
   ```
 
+  If you would like to determine your external IP with a shell command instead
+  of using external services, specify the command to run in the 'command' key:
+
+  ```json
+    "command": "ipconfig getifaddr en0"
+  ```
+
+  The command should return the external IP address on stdout.
+
 1. Save and close the file.
 
 #### Running the Script

--- a/gandi_dyndns.py
+++ b/gandi_dyndns.py
@@ -4,6 +4,7 @@ import collections
 import json
 import random
 import re
+import subprocess
 import time
 import urllib2
 import xmlrpclib
@@ -130,6 +131,9 @@ def get_external_ip(attempts=100, threshold=3):
   # return None if no agreement could be reached
   return None
 
+def get_local_ip(cmd):
+  return subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout.read().strip()
+
 def load_providers():
   '''Load the providers file as a de-duplicated and normalized list of URLs.'''
   with open('providers.json') as f:
@@ -193,8 +197,12 @@ def update_ip():
   gandi = GandiServerProxy(config['api_key'])
 
   # see if the record's IP differs from ours
-  log.debug('Getting external IP...')
-  external_ip = get_external_ip()
+  if 'command' in config:
+    log.debug('Getting external IP using command: ' + config['command'])
+    external_ip = get_local_ip(config['command'])
+  else:
+    log.debug('Getting external IP...')
+    external_ip = get_external_ip()
 
   log.debug('External IP is: %s', external_ip)
 


### PR DESCRIPTION
In some cases, the system running `gandhi_dyndns.py` knows its public external IP address, so we can skip the queries to external IP lookup services. This PR adds the ability to determine external IP via a arbitrary shell command stored in `config.json`.

This may help with issue #2 