### PR TITLE
Add gandi-automatic-dns to alternative projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ more information about the API change and reasons for the deprecation.
 ## Alternative Projects
 Here are alternative projects that users have recommended:
 * https://github.com/cavebeat/gandi-live-dns
+* https://github.com/brianpcurran/gandi-automatic-dns
 
 If you have suggestions for other alternative projects, please open a new issue
 or pull request to discuss adding them.


### PR DESCRIPTION
Now that it works with Gandi v5/LiveDNS, I've added my project gandi-automatic-dns to the README as an alternative project.